### PR TITLE
Add travis gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ group :test, :development do
   gem 'quiet_assets'
   gem 'database_cleaner'
   gem 'rake', '~> 10.4.2'
-
+  gem 'travis'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,5 +254,6 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   shoulda-matchers
   spring
+  travis
   uglifier (>= 1.3.0)
   valid_attribute


### PR DESCRIPTION
Includes travis in Gemfile to generate secure environment variables for testing, per [Travis-ci docs](http://docs.travis-ci.com/user/environment-variables/)